### PR TITLE
distance functions and hhbayer tests

### DIFF
--- a/src/semantic_similarity.py
+++ b/src/semantic_similarity.py
@@ -1,10 +1,13 @@
 import pandas as pd
+import torch
 from nltk.translate.bleu_score import sentence_bleu
 from nltk.tokenize import word_tokenize
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.metrics import jaccard_score
 from sentence_transformers import SentenceTransformer
+from scipy.spatial import distance
+from math import acos, pi
 
 # Function to calculate the metrics for each row
 def calculate_overlap(row, string1, string2):
@@ -53,6 +56,86 @@ def calculate_embedding_cosine(row, string1, string2):
 
     return pd.Series({'Cosine_Similarity': cosine_sim})
 
-# def calculate_embedding_euclidean():
+def calculate_embedding_euclidean(row, string1, string2):
+    '''
+    Calculate euclidean distance between sentence embeddings.
+    Input: row with 'string1' and 'string2' fields defined
+    Output: Series with euclidean distance greater than or equal to 0
+    '''
+
+    sent1 = row[string1]
+    sent2 = row[string2]
+
+    if len(sent1.strip()) == 0 or len(sent2.strip()) == 0:
+        raise ValueError("Empty string input detected")
+    else:
+        pass
+
+    # Load pre-trained sentence transformer model
+    model = SentenceTransformer('all-MiniLM-L6-v2')
+
+       # Generate embeddings for both sentences
+    embedding1 = model.encode([sent1], convert_to_tensor=True)
+    embedding2 = model.encode([sent2], convert_to_tensor=True)
+
+    # Calculate euclidian distance 
+    euclidean_dist = distance.euclidean(embedding1.squeeze().cpu().numpy(), embedding2.squeeze().cpu().numpy())
+
+    return pd.Series({'Euclidean_Distance': euclidean_dist})
+
+
+def calculate_embedding_manhattan(row, string1, string2):
+    '''
+    Calculate manhattan distance between sentence embeddings.
+    Input: row with 'string1' and 'string2' fields defined
+    Output: Series with manhattan distance greater than or equal to 0
+    '''
+
+    sent1 = row[string1]
+    sent2 = row[string2]
+    
+    if len(sent1.strip()) == 0 or len(sent2.strip()) == 0:
+        raise ValueError("Empty string input detected")
+    else:
+        pass
+
+    # Load pre-trained sentence transformer model
+    model = SentenceTransformer('all-MiniLM-L6-v2')
+
+    # Generate embeddings for both sentences
+    embedding1 = model.encode([sent1], convert_to_tensor=True)
+    embedding2 = model.encode([sent2], convert_to_tensor=True)
+
+    # Calculate manhattan distance 
+    manhattan_dist = distance.cityblock(embedding1.squeeze().cpu().numpy(), embedding2.squeeze().cpu().numpy())
+
+    return pd.Series({'Manhattan_Distance': manhattan_dist})
+
+def calculate_embedding_angular(row, string1, string2):
+    '''
+    Calculate angular distance between sentence embeddings.
+    Input: row with 'string1' and 'string2' fields defined
+    Output: Series with angular distance greater than or equal to 0
+    '''
+
+    sent1 = row[string1]
+    sent2 = row[string2]
+
+    if len(sent1.strip()) == 0 or len(sent2.strip()) == 0:
+        raise ValueError("Empty string input detected")
+    else:
+        pass
+
+    # Load pre-trained sentence transformer model
+    model = SentenceTransformer('all-MiniLM-L6-v2')
+
+    # Generate embeddings for both sentences
+    embedding1 = model.encode([sent1], convert_to_tensor=True)
+    embedding2 = model.encode([sent2], convert_to_tensor=True)
+
+    # Calculate euclidian distance 
+    angular_dist = acos(1 - distance.cosine(embedding1.squeeze().cpu().numpy(), embedding2.squeeze().cpu().numpy()))/pi
+
+    return pd.Series({'Angular_Distance': angular_dist})
 
 

--- a/src/semantic_similarity.py
+++ b/src/semantic_similarity.py
@@ -1,6 +1,7 @@
 import os
 import json
 import pandas as pd
+import torch
 from nltk.translate.bleu_score import sentence_bleu
 from nltk.tokenize import word_tokenize
 from sklearn.feature_extraction.text import CountVectorizer
@@ -8,6 +9,8 @@ from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.metrics import jaccard_score
 from sentence_transformers import SentenceTransformer
 from openai import OpenAI
+from scipy.spatial import distance
+from math import acos, pi
 
 # Function to calculate the metrics for each row
 def calculate_overlap(row, string1, string2):
@@ -155,5 +158,86 @@ Respond ONLY with a JSON object of the form:
     )
 
 # def calculate_embedding_euclidean():
+def calculate_embedding_euclidean(row, string1, string2):
+    '''
+    Calculate euclidean distance between sentence embeddings.
+    Input: row with 'string1' and 'string2' fields defined
+    Output: Series with euclidean distance greater than or equal to 0
+    '''
+
+    sent1 = row[string1]
+    sent2 = row[string2]
+
+    if len(sent1.strip()) == 0 or len(sent2.strip()) == 0:
+        raise ValueError("Empty string input detected")
+    else:
+        pass
+
+    # Load pre-trained sentence transformer model
+    model = SentenceTransformer('all-MiniLM-L6-v2')
+
+       # Generate embeddings for both sentences
+    embedding1 = model.encode([sent1], convert_to_tensor=True)
+    embedding2 = model.encode([sent2], convert_to_tensor=True)
+
+    # Calculate euclidian distance 
+    euclidean_dist = distance.euclidean(embedding1.squeeze().cpu().numpy(), embedding2.squeeze().cpu().numpy())
+
+    return pd.Series({'Euclidean_Distance': euclidean_dist})
+
+
+def calculate_embedding_manhattan(row, string1, string2):
+    '''
+    Calculate manhattan distance between sentence embeddings.
+    Input: row with 'string1' and 'string2' fields defined
+    Output: Series with manhattan distance greater than or equal to 0
+    '''
+
+    sent1 = row[string1]
+    sent2 = row[string2]
+    
+    if len(sent1.strip()) == 0 or len(sent2.strip()) == 0:
+        raise ValueError("Empty string input detected")
+    else:
+        pass
+
+    # Load pre-trained sentence transformer model
+    model = SentenceTransformer('all-MiniLM-L6-v2')
+
+    # Generate embeddings for both sentences
+    embedding1 = model.encode([sent1], convert_to_tensor=True)
+    embedding2 = model.encode([sent2], convert_to_tensor=True)
+
+    # Calculate manhattan distance 
+    manhattan_dist = distance.cityblock(embedding1.squeeze().cpu().numpy(), embedding2.squeeze().cpu().numpy())
+
+    return pd.Series({'Manhattan_Distance': manhattan_dist})
+
+def calculate_embedding_angular(row, string1, string2):
+    '''
+    Calculate angular distance between sentence embeddings.
+    Input: row with 'string1' and 'string2' fields defined
+    Output: Series with angular distance greater than or equal to 0
+    '''
+
+    sent1 = row[string1]
+    sent2 = row[string2]
+
+    if len(sent1.strip()) == 0 or len(sent2.strip()) == 0:
+        raise ValueError("Empty string input detected")
+    else:
+        pass
+
+    # Load pre-trained sentence transformer model
+    model = SentenceTransformer('all-MiniLM-L6-v2')
+
+    # Generate embeddings for both sentences
+    embedding1 = model.encode([sent1], convert_to_tensor=True)
+    embedding2 = model.encode([sent2], convert_to_tensor=True)
+
+    # Calculate euclidian distance 
+    angular_dist = acos(1 - distance.cosine(embedding1.squeeze().cpu().numpy(), embedding2.squeeze().cpu().numpy()))/pi
+
+    return pd.Series({'Angular_Distance': angular_dist})
 
 

--- a/tech_review/03-embedding_other.ipynb
+++ b/tech_review/03-embedding_other.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "e54d7c4b",
    "metadata": {},
    "outputs": [],
@@ -64,8 +64,8 @@
     "    emb2 = model.encode(text_b, convert_to_tensor=True)\n",
     "\n",
     "    # compute distances\n",
-    "    distances.at[index, 'euclidean'] = distance.euclidean(emb1.cpu().numpy(), emb2.cpu().numpy())\n",
-    "    distances.at[index, 'manhattan'] = distance.cityblock(emb1.cpu().numpy(), emb2.cpu().numpy()) \n",
+    "    distances.at[index, 'euclidean'] = distance.euclidean(emb1.squeeze().cpu().numpy(), emb2.cpu().numpy())\n",
+    "    distances.at[index, 'manhattan'] = distance.cityblock(emb1.squeeze().cpu().numpy(), emb2.cpu().numpy()) \n",
     "    distances.at[index, 'dot_product'] = torch.dot(emb1, emb2).item()\n",
     "    distances.at[index, 'angular'] = acos(1 - distance.cosine(emb1.cpu().numpy(), emb2.cpu().numpy()))/pi"
    ]
@@ -215,7 +215,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "topicbench",
    "language": "python",
    "name": "python3"
   },
@@ -229,7 +229,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/tests/james_tests.py
+++ b/tests/james_tests.py
@@ -1,0 +1,85 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pandas as pd
+from nltk.translate.bleu_score import sentence_bleu
+from nltk.tokenize import word_tokenize
+from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.metrics import jaccard_score
+import pytest
+import numpy as np
+
+# Loading up CSV
+csv_path = Path(__file__).parent.parent / 'tech_review' / 'evaluation_cases.csv'
+df = pd.read_csv(csv_path)
+
+def calculate_metrics(row):
+    sent1 = row['sent1']
+    sent2 = row['sent2']
+    tokens1 = word_tokenize(sent1.lower())
+    tokens2 = word_tokenize(sent2.lower())
+    bleu = sentence_bleu([tokens2], tokens1)
+    vectorizer = CountVectorizer(binary=True)
+    X = vectorizer.fit_transform([sent1, sent2]).toarray()
+    jaccard = jaccard_score(X[0], X[1])
+    return pd.Series({'BLEU': bleu, 'Jaccard': jaccard})
+
+metrics_df = df.apply(calculate_metrics, axis=1)
+
+
+# Smoke Test
+def test_smoke_metrics_execute():
+    """
+    author: James Stewart
+    category: smoke test
+    justification: Verifies that calculate_metrics runs and produces expected columns without error.
+    """
+    assert metrics_df is not None # Is the dataframe there?
+    assert len(metrics_df) == 4 # Are there four rows?
+    assert 'BLEU' in metrics_df.columns and 'Jaccard' in metrics_df.columns # Does it have BLEU and Jaccard?
+
+
+# One-Shot Test
+def test_oneshot_identical_sentences():
+    """
+    author: James Stewart
+    category: one-shot test
+    justification: Checks that identical sentences yield perfect similarity scores.
+    """
+    test_data = pd.DataFrame({
+        'sent1': ['he ran quickly to the store'],
+        'sent2': ['he ran quickly to the store']
+    })
+    result = test_data.apply(calculate_metrics, axis=1) # With the two same sentences, do they score the same?
+    assert result.iloc[0]['BLEU'] == 1.0
+    assert result.iloc[0]['Jaccard'] == 1.0
+
+
+# Edge Test
+def test_edge_no_token_overlap():
+    """
+    author: James Stewart
+    category: edge test
+    justification: Validates that completely different sentences yield zero similarity scores.
+    """
+    test_data = pd.DataFrame({
+        'sent1': ['turn left at the traffic light'],
+        'sent2': ['photosynthesis occurs in plant cells']
+    })
+    result = test_data.apply(calculate_metrics, axis=1) # With two completely different sentences, do they score zero?
+    np.testing.assert_allclose(result.iloc[0]['BLEU'], 0.0, atol=0.01)
+    np.testing.assert_allclose(result.iloc[0]['Jaccard'], 0.0, atol=0.01)
+
+
+# Pattern Test
+def test_pattern_token_overlap_behavior():
+    """
+    author: James Stewart
+    category: pattern test
+    justification: Confirms that the expected pattern of token overlap scores is produced for the sample data.
+    """
+    expected_bleu = [0, 1, 0, 0] # These are the scores we're expecting from the sample
+    expected_jaccard = [0, 1, 0, 0]
+    np.testing.assert_allclose(metrics_df['BLEU'], expected_bleu, atol=0.1)
+    np.testing.assert_allclose(metrics_df['Jaccard'], expected_jaccard, atol=0.1)

--- a/tests/test_semantic_similarity.py
+++ b/tests/test_semantic_similarity.py
@@ -192,7 +192,7 @@ def test_llm_as_judge_pattern_parses_response(monkeypatch):
 def test_embedding_manhattan():
    """
     author: hhbayer
-    reviewer: avisokay
+    reviewer: zilin49
     category: (i) Smoke Test
     """
    manhattan_df = calculate_embedding_manhattan(df.iloc[0], 'sent1', 'sent2')
@@ -201,7 +201,7 @@ def test_embedding_manhattan():
 def test_embedding_euclidean():
    """
     author: hhbayer
-    reviewer: avisokay
+    reviewer: zilin49
     category: (ii) One-Shot Test
     """
    euclidean_df = df.apply(calculate_embedding_euclidean, axis=1, string1='sent1', string2='sent2')
@@ -210,7 +210,7 @@ def test_embedding_euclidean():
 def test_embeddings_angular():
    """
     author: hhbayer
-    reviewer: avisokay
+    reviewer: zilin49
     category: (iii) Edge Test
     """
    bad_input_df = pd.DataFrame({
@@ -228,14 +228,15 @@ def test_embeddings_angular():
 def test_distances_pattern():
    """
     author: hhbayer
-    reviewer: avisokay
+    reviewer: zilin49
     category: (iv) Pattern Test
     """
-   #test three distance methods on df 
+   # Calculate three distance measures on sample sentences in df
    euclidean_df = df.apply(calculate_embedding_euclidean, axis=1, string1='sent1', string2='sent2')
    manhattan_df = df.apply(calculate_embedding_manhattan, axis=1, string1='sent1', string2='sent2')
    angular_df = df.apply(calculate_embedding_angular, axis=1, string1='sent1', string2='sent2')
-   # Pattern: ranked distances should be consistent across methods
+
+   # Pattern: ranked distances should be consistent across distance measures
    euclidean_ranks = euclidean_df['Euclidean_Distance'].rank().tolist()
    manhattan_ranks = manhattan_df['Manhattan_Distance'].rank().tolist()
    angular_ranks = angular_df['Angular_Distance'].rank().tolist()

--- a/tests/test_semantic_similarity.py
+++ b/tests/test_semantic_similarity.py
@@ -7,10 +7,8 @@ from nltk.translate.bleu_score import sentence_bleu
 from nltk.tokenize import word_tokenize
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.metrics import jaccard_score
-from src.semantic_similarity import (calculate_overlap, 
-                                     calculate_embedding_cosine, 
-                                     calculate_llm_as_judge)
 from src.validate import compute_alignment
+from src.semantic_similarity import (calculate_overlap, calculate_embedding_cosine,calculate_embedding_manhattan, calculate_embedding_euclidean, calculate_embedding_angular, alculate_llm_as_judge)
 import pytest
 import numpy as np
 import os
@@ -189,3 +187,60 @@ def test_llm_as_judge_pattern_parses_response(monkeypatch):
 
     assert isinstance(result["LLM_Rationale"], str)
     assert "paraphrases" in result["LLM_Rationale"]
+
+
+def test_embedding_manhattan():
+   """
+    author: hhbayer
+    reviewer: avisokay
+    category: (i) Smoke Test
+    """
+   manhattan_df = calculate_embedding_manhattan(df.iloc[0], 'sent1', 'sent2')
+   assert isinstance(manhattan_df, pd.Series)
+
+def test_embedding_euclidean():
+   """
+    author: hhbayer
+    reviewer: avisokay
+    category: (ii) One-Shot Test
+    """
+   euclidean_df = df.apply(calculate_embedding_euclidean, axis=1, string1='sent1', string2='sent2')
+   np.testing.assert_allclose(euclidean_df['Euclidean_Distance'], [0.935487, 0.0, 0.842431, 1.41078], atol=0.1)
+
+def test_embeddings_angular():
+   """
+    author: hhbayer
+    reviewer: avisokay
+    category: (iii) Edge Test
+    """
+   bad_input_df = pd.DataFrame({
+    'sent1': [
+        ''
+    ],
+    'sent2': [
+        ''
+    ]
+    })
+
+   with pytest.raises(ValueError, match="Empty string input"):
+      calculate_embedding_angular(bad_input_df.iloc[0], 'sent1', 'sent2')
+
+def test_distances_pattern():
+   """
+    author: hhbayer
+    reviewer: avisokay
+    category: (iv) Pattern Test
+    """
+   #test three distance methods on df 
+   euclidean_df = df.apply(calculate_embedding_euclidean, axis=1, string1='sent1', string2='sent2')
+   manhattan_df = df.apply(calculate_embedding_manhattan, axis=1, string1='sent1', string2='sent2')
+   angular_df = df.apply(calculate_embedding_angular, axis=1, string1='sent1', string2='sent2')
+   # Pattern: ranked distances should be consistent across methods
+   euclidean_ranks = euclidean_df['Euclidean_Distance'].rank().tolist()
+   manhattan_ranks = manhattan_df['Manhattan_Distance'].rank().tolist()
+   angular_ranks = angular_df['Angular_Distance'].rank().tolist()
+   assert euclidean_ranks == manhattan_ranks == angular_ranks
+   
+   
+   
+

--- a/tests/test_semantic_similarity.py
+++ b/tests/test_semantic_similarity.py
@@ -45,7 +45,7 @@ def test_embeddings_cosine():
 def test_embedding_manhattan():
    """
     author: hhbayer
-    reviewer: avisokay
+    reviewer: zilin49
     category: (i) Smoke Test
     """
    manhattan_df = calculate_embedding_manhattan(df.iloc[0], 'sent1', 'sent2')
@@ -54,7 +54,7 @@ def test_embedding_manhattan():
 def test_embedding_euclidean():
    """
     author: hhbayer
-    reviewer: avisokay
+    reviewer: zilin49
     category: (ii) One-Shot Test
     """
    euclidean_df = df.apply(calculate_embedding_euclidean, axis=1, string1='sent1', string2='sent2')
@@ -63,7 +63,7 @@ def test_embedding_euclidean():
 def test_embeddings_angular():
    """
     author: hhbayer
-    reviewer: avisokay
+    reviewer: zilin49
     category: (iii) Edge Test
     """
    bad_input_df = pd.DataFrame({
@@ -81,14 +81,15 @@ def test_embeddings_angular():
 def test_distances_pattern():
    """
     author: hhbayer
-    reviewer: avisokay
+    reviewer: zilin49
     category: (iv) Pattern Test
     """
-   #test three distance methods on df 
+   # Calculate three distance measures on sample sentences in df
    euclidean_df = df.apply(calculate_embedding_euclidean, axis=1, string1='sent1', string2='sent2')
    manhattan_df = df.apply(calculate_embedding_manhattan, axis=1, string1='sent1', string2='sent2')
    angular_df = df.apply(calculate_embedding_angular, axis=1, string1='sent1', string2='sent2')
-   # Pattern: ranked distances should be consistent across methods
+
+   # Pattern: ranked distances should be consistent across distance measures
    euclidean_ranks = euclidean_df['Euclidean_Distance'].rank().tolist()
    manhattan_ranks = manhattan_df['Manhattan_Distance'].rank().tolist()
    angular_ranks = angular_df['Angular_Distance'].rank().tolist()

--- a/tests/test_semantic_similarity.py
+++ b/tests/test_semantic_similarity.py
@@ -7,7 +7,7 @@ from nltk.translate.bleu_score import sentence_bleu
 from nltk.tokenize import word_tokenize
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.metrics import jaccard_score
-from src.semantic_similarity import calculate_overlap, calculate_embedding_cosine
+from src.semantic_similarity import calculate_overlap, calculate_embedding_cosine,calculate_embedding_manhattan, calculate_embedding_euclidean, calculate_embedding_angular
 import pytest
 import numpy as np
 
@@ -41,3 +41,59 @@ def test_semantic_similarity_metrics():
 def test_embeddings_cosine():
     # Assert that scores are as expected
     np.testing.assert_allclose(cosine_df['Cosine_Similarity'], [0.562432, 1, 0.645155, 0.004850], atol=0.1)
+
+def test_embedding_manhattan():
+   """
+    author: hhbayer
+    reviewer: avisokay
+    category: (i) Smoke Test
+    """
+   manhattan_df = calculate_embedding_manhattan(df.iloc[0], 'sent1', 'sent2')
+   assert isinstance(manhattan_df, pd.Series)
+
+def test_embedding_euclidean():
+   """
+    author: hhbayer
+    reviewer: avisokay
+    category: (ii) One-Shot Test
+    """
+   euclidean_df = df.apply(calculate_embedding_euclidean, axis=1, string1='sent1', string2='sent2')
+   np.testing.assert_allclose(euclidean_df['Euclidean_Distance'], [0.935487, 0.0, 0.842431, 1.41078], atol=0.1)
+
+def test_embeddings_angular():
+   """
+    author: hhbayer
+    reviewer: avisokay
+    category: (iii) Edge Test
+    """
+   bad_input_df = pd.DataFrame({
+    'sent1': [
+        ''
+    ],
+    'sent2': [
+        ''
+    ]
+    })
+
+   with pytest.raises(ValueError, match="Empty string input"):
+      calculate_embedding_angular(bad_input_df.iloc[0], 'sent1', 'sent2')
+
+def test_distances_pattern():
+   """
+    author: hhbayer
+    reviewer: avisokay
+    category: (iv) Pattern Test
+    """
+   #test three distance methods on df 
+   euclidean_df = df.apply(calculate_embedding_euclidean, axis=1, string1='sent1', string2='sent2')
+   manhattan_df = df.apply(calculate_embedding_manhattan, axis=1, string1='sent1', string2='sent2')
+   angular_df = df.apply(calculate_embedding_angular, axis=1, string1='sent1', string2='sent2')
+   # Pattern: ranked distances should be consistent across methods
+   euclidean_ranks = euclidean_df['Euclidean_Distance'].rank().tolist()
+   manhattan_ranks = manhattan_df['Manhattan_Distance'].rank().tolist()
+   angular_ranks = angular_df['Angular_Distance'].rank().tolist()
+   assert euclidean_ranks == manhattan_ranks == angular_ranks
+   
+   
+   
+


### PR DESCRIPTION
I added functions to calculate euclidian, manhattan, and angular distance measures. I also wrote four different tests for these functions:

(1) test_embedding_manhattan: a smoke test that runs calculate_embedding_manhattan on a single pair of sample sentences and checks if output type is correct

(2) test_embedding_euclidean: a one-shot test that checks whether calculate_embedding_euclidean returns expected distances for four test phrase pairs

(3) test_embeddings_angular: a edge test that makes sure a value error is returned if empty input is given

(4) test_distances_pattern: a pattern test that makes sure the distance measures all rank the distance between the phrase pairs in the same order